### PR TITLE
Bump Checkstyle version to latest (`8.7`)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>6.19</version>
+                        <version>8.7</version>
                     </dependency>
                 </dependencies>
                 <configuration>


### PR DESCRIPTION
* [x] Bump Checkstyle version
* [ ] Bump viskan/checkstyle-configuration#8 to version `6` (after releasing it)

Closes #20 
 